### PR TITLE
Add units, update excel upload

### DIFF
--- a/multic/cli/FeatureExtraction/FeatureExtraction.py
+++ b/multic/cli/FeatureExtraction/FeatureExtraction.py
@@ -52,6 +52,7 @@ def main(args):
         item_dict.update(d)
     
     file_id = item_dict[file_name]
+    xlsx_path = os.path.join(args.base_dir, os.path.basename(file_name).split('.')[0] +'_pathomic'+'.xlsx')
 
     annotations = gc.get('/annotation/item/{}'.format(file_id))
 
@@ -75,17 +76,19 @@ def main(args):
 
 
     all_comparts = [gloms,s_gloms,tubs, arts]
-    all_columns = [['x1','x2','y1','y2','Area','Mesangial Area','Mesangial Fraction'],
-                   ['x1','x2','y1','y2','Area','Mesangial Area','Mesangial Fraction'],
-                   ['x1','x2','y1','y2','Average TBM Thickness','Average Cell Thickness','Luminal Fraction'],
-                   ['x1','x2','y1','y2','Arterial Area']]
+    all_columns = [['x1','x2','y1','y2','Area (micron^2)','Mesangial Area (micron^2)','Mesangial Fraction'],
+                   ['x1','x2','y1','y2','Area (micron^2)','Mesangial Area (micron^2)','Mesangial Fraction'],
+                   ['x1','x2','y1','y2','Average TBM Thickness (micron)','Average Cell Thickness (micron)','Luminal Fraction'],
+                   ['x1','x2','y1','y2','Arterial Area (micron^2)']]
     compart_names = ['gloms','s_gloms','tubs','arts']
     
-    _ = os.system("printf '\tWriting Excel file: [{}]\n'".format(args.output_filename))
-    with pd.ExcelWriter(args.output_filename) as writer:
+    _ = os.system("printf '\tWriting Excel file: [{}]\n'".format(xlsx_path))
+    with pd.ExcelWriter(xlsx_path) as writer:
         for idx,compart in enumerate(all_comparts):
             df = pd.DataFrame(compart,columns=all_columns[idx])
             df.to_excel(writer, index=False, sheet_name=compart_names[idx])
+    
+    gc.uploadFileToItem(file_id, xlsx_path, reference=None, mimeType=None, filename=None, progressCallback=None)
 
 if __name__ == "__main__":
     main(CLIArgumentParser().parse_args())

--- a/multic/cli/FeatureExtraction/FeatureExtraction.xml
+++ b/multic/cli/FeatureExtraction/FeatureExtraction.xml
@@ -33,13 +33,6 @@
       <channel>input</channel>
       <index>2</index>
     </double>
-    <file fileExtensions=".xlsx" reference="output">
-      <name>output_filename</name>
-      <label>Output Excel Filename</label>
-      <description>Select the name and location of the Excel file produced. By default this will be saved in your Private folder.</description>
-      <channel>output</channel>
-      <index>3</index>
-    </file>
   </parameters>
   <parameters advanced="true">
     <label>Deconvolution Thresholds</label>

--- a/multic/segmentationschool/extraction_utils/process_mc_features.py
+++ b/multic/segmentationschool/extraction_utils/process_mc_features.py
@@ -160,8 +160,8 @@ def process_tubules_features(mask_xml, tub_value, MOD, slide, mpp, whitespace_th
         tubs[i,1] = x2
         tubs[i,2] = y1
         tubs[i,3] = y2
-        tubs[i,4] = tbm_avg*(mpp**2)
-        tubs[i,5] = cyto_avg*(mpp**2)
+        tubs[i,4] = tbm_avg*mpp
+        tubs[i,5] = cyto_avg*mpp
         tubs[i,6] = np.sum(WS) / np.sum(mask)#
 
     del tubules


### PR DESCRIPTION
This PR updates the pathomic feature extraction plugins as follows:

- Add units to feature columns (micron and micron^2)
- Fix a bug in `tbm tickness` and `Average Cell Thickness` unit conversion
- upload the resulting excel spreadsheet directly to the image, similar to other 2 FE plugins.